### PR TITLE
2차PR대상리뷰요청

### DIFF
--- a/src/main/java/com/plusbackend/week2/controller/LectureController.java
+++ b/src/main/java/com/plusbackend/week2/controller/LectureController.java
@@ -2,13 +2,11 @@ package com.plusbackend.week2.controller;
 
 import com.plusbackend.week2.dto.EnrollmentDTO;
 import com.plusbackend.week2.dto.ResponseDTO;
-import com.plusbackend.week2.dto.UserDTO;
 import com.plusbackend.week2.service.EnrollmentService;
 import com.plusbackend.week2.service.LectureService;
 import com.plusbackend.week2.validation.UserIdValidator;
 import jakarta.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,5 +40,5 @@ public class LectureController {
         UserIdValidator.isValid(userId);
         ResponseDTO responseDto = lectureService.getAvailableLecture(userId);
         return ResponseEntity.ok(responseDto);
-    }
+    }  //git add
 }

--- a/src/main/java/com/plusbackend/week2/domain/Enrollment.java
+++ b/src/main/java/com/plusbackend/week2/domain/Enrollment.java
@@ -25,6 +25,6 @@ public class Enrollment {
 
     public Enrollment(EnrollmentId enrollmentId) {
         this.id = enrollmentId;
-    }
+    }  //git add
 
 }

--- a/src/main/java/com/plusbackend/week2/domain/EnrollmentId.java
+++ b/src/main/java/com/plusbackend/week2/domain/EnrollmentId.java
@@ -23,4 +23,4 @@ public class EnrollmentId implements Serializable {
     @Column(name = "lecture_dy")
     private String lectureDy;
 
-}
+}  //git add

--- a/src/main/java/com/plusbackend/week2/repository/EnrollmentRepository.java
+++ b/src/main/java/com/plusbackend/week2/repository/EnrollmentRepository.java
@@ -16,3 +16,4 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Enrollme
     List<Enrollment> findByIdUserId(Long userId);
 
 }
+//git add

--- a/src/main/java/com/plusbackend/week2/repository/EnrollmentRepositoryCustom.java
+++ b/src/main/java/com/plusbackend/week2/repository/EnrollmentRepositoryCustom.java
@@ -11,4 +11,4 @@ public interface EnrollmentRepositoryCustom {
 
     public List<Enrollment> findByLectureIdAndLectureDy(long lectureId , String lectureDy);
 
-}
+} //git add

--- a/src/main/java/com/plusbackend/week2/repository/impl/EnrollmentRepositoryImpl.java
+++ b/src/main/java/com/plusbackend/week2/repository/impl/EnrollmentRepositoryImpl.java
@@ -26,5 +26,5 @@ public class EnrollmentRepositoryImpl implements EnrollmentRepositoryCustom {
                 .getResultList();
     }
 
-
+    //git add
 }

--- a/src/main/java/com/plusbackend/week2/repository/impl/LectureScheduleRepositoryImpl.java
+++ b/src/main/java/com/plusbackend/week2/repository/impl/LectureScheduleRepositoryImpl.java
@@ -67,6 +67,6 @@ public class LectureScheduleRepositoryImpl implements LectureScheduleRepositoryC
     }
 
 
-
+    //git add
 
 }

--- a/src/main/java/com/plusbackend/week2/service/impl/EnrollmentServiceImpl.java
+++ b/src/main/java/com/plusbackend/week2/service/impl/EnrollmentServiceImpl.java
@@ -70,7 +70,7 @@ public class EnrollmentServiceImpl  implements EnrollmentService {
 
 
         return new ResponseDTO("200" , ResponseMessage.ENROLLMENT_SUCCESS.getMessage());
-    }
+    } //git add
 
 
 }

--- a/src/test/java/com/plusbackend/week2/integration/service/ApplyLectureConcurrentTest.java
+++ b/src/test/java/com/plusbackend/week2/integration/service/ApplyLectureConcurrentTest.java
@@ -115,3 +115,4 @@ public class ApplyLectureConcurrentTest {
         Assertions.assertThat(enrollments.size()).isEqualTo(30);
     }
 }
+//git add

--- a/src/test/java/com/plusbackend/week2/unit/service/ApplyLectureTest.java
+++ b/src/test/java/com/plusbackend/week2/unit/service/ApplyLectureTest.java
@@ -94,4 +94,4 @@ public class ApplyLectureTest extends LectureServiceBase {
         verify(enrollmentRepository, times(1)).findById(any(EnrollmentId.class));
         verify(enrollmentRepository, never()).save(any(Enrollment.class));
     }
-}
+} //git add


### PR DESCRIPTION
# 변경 사항

- 동시성 조건 추가 
 EnrollmentServiceImpl.java 로 비관락 기법을 이용한 동시성 제어를 하였습니다. 


# 리뷰 포인트

- ERD의 타당성 여부를 함께 이야기해보고 싶습니다.
  
![image](https://github.com/0216tw/hhplus-tdd-java-2week/assets/140934688/9fb2933a-46b4-4d71-835b-0070cbcaa01d)

- 아키텍처의 적절성 및 의견이 궁금합니다. 

![image](https://github.com/0216tw/hhplus-tdd-java-2week/assets/140934688/a7a2dadc-0bc5-4fcf-b74e-48955296416b)

![image](https://github.com/0216tw/hhplus-tdd-java-2week/assets/140934688/0fedb845-8e77-4021-9a3c-4cc9dc2ce2d5)

![image](https://github.com/0216tw/hhplus-tdd-java-2week/assets/140934688/4baaa3f0-94f5-4d02-894f-f4f57a562b5c)


- 비관락을 사용한 동시성 제어에 대한 코드 리뷰를 부탁드립니다. (코드 및 테스트코드 업로드)

<동시성 제어 관련 테스트 소스 코드> 
ApplyLectureConcurrentTest

<동시성 관련 코드> 
LectureController.java (컨트롤러)
Enrollment.java (도메인) 
EnrollmentId.java (도메인 복합키) 
EnrollmentServiceImpl.java (서비스) 
EnrollmentRepository.java (레포) 
EnrollmentRepositoryCustom.java (레포지토리 확장) 
EnrollmentRepositoryImpl.java (레포 구현체) 
LectureScheduleRepositoryImpl.java (레포 구현체) 



# 추가 궁금증 

INSERT 가 잦은 환경이라면 락을 고려할 필요가 없는지 궁금합니다. 
제 경우에는 낙관락 , 비관락 모두 UPDATE , DELETE 등에는 영향을 주지만 
INSERT 는 테이블 범위 이후이기에 괜찮다라고 생각했습니다. 


커밋 단위를 쪼개는 것에 서툴러 주석을 추가하여 필요한 대상만 추가했습니다. (expand up 부탁드립니다 ㅠㅠ)
추후부터는 커밋단위로 쪼개어 제출 잘 하도록 하겠습니다. 
감사합니다!
